### PR TITLE
Added helper scripts in scripts/ dir

### DIFF
--- a/scripts/energi3-status
+++ b/scripts/energi3-status
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+
+
+while true
+do
+
+	echo ""
+
+	if [[ -z "${ENERGI_WALLET_ADDR}" ]] ; then
+
+		echo "No wallet address is set! You may edit this script or enter it below."
+
+		read -p "Enter wallet address: " ENERGI_WALLET_ADDR
+
+		if [ -n "$ENERGI_WALLET_ADDR" ]; then
+
+			export ENERGI_WALLET_ADDRESS=${ENERGI_WALLET_ADDR}
+
+		fi
+
+	else
+
+		break
+
+	fi
+
+done
+
+
+# Define unlock command
+UNLOCK_CMD="miner.stakingStatus()"
+
+# Unlock the account (asks user for password)
+energi3 attach --exec "${UNLOCK_CMD}"
+
+echo ""
+
+exit 0

--- a/scripts/energi3-unlock
+++ b/scripts/energi3-unlock
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+
+while true
+do
+
+	echo ""
+
+	if [[ -z "${ENERGI_WALLET_ADDR}" ]] ; then
+
+		echo "No wallet address is set! You may edit this script or enter it below."
+
+		read -p "Enter wallet address: " ENERGI_WALLET_ADDR
+
+		if [ -n "$ENERGI_WALLET_ADDR" ]; then
+
+			break
+
+		fi
+
+	else
+
+		break
+
+	fi
+
+done
+
+# Define unlock command
+UNLOCK_CMD="personal.unlockAccount('${ENERGI_WALLET_ADDR}', null, 0, true)"
+
+# Unlock the account (asks user for password)
+energi3 attach --exec "${UNLOCK_CMD}"
+
+echo ""
+
+exit

--- a/scripts/install-scripts.sh
+++ b/scripts/install-scripts.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+PWD=$(pwd)
+CWD=$(cwd)
+
+WALLET_ADDR=""
+
+echo ""
+echo "PWD [${PWD}]"
+echo ""
+
+while true
+do
+	echo ""
+	echo "Only run this script once to install."
+	echo "Do NOT move the files once installed!"
+	echo ""
+
+	read -p "Ok? [Y/y/N/n] " ANSWER
+
+	case $ANSWER in
+
+   		[yY]* ) break;;
+	   	[nN]* ) exit;;
+   		* )     echo "Only enter [Y/y/N/n] please!.";
+ 	esac
+
+done
+
+while true
+do
+
+        echo ""
+
+        if [[ "$WALLET_ADDR" == "WALLET_ADDRESS_HERE" || -z "${WALLET_ADDR}" ]] ; then
+
+                echo "No wallet address is set! You may edit this script or enter it below."
+
+                read -p "Enter wallet address: " WALLET_ADDR
+
+                if [ -n "$WALLET_ADDR" ]; then
+
+                        break
+
+                fi
+
+        fi
+
+done
+
+
+export PATH=${PATH}:${PWD}/
+
+echo "" >> ~/.bashrc
+echo "" >> ~/.bashrc
+echo "# LINE BELOW PUT HERE BY ENERGI HELPER SCRIPTS (UNOFFICIAL)" >> ~/.bashrc
+echo "PATH=\${PATH}:${PWD}" >> ~/.bashrc
+echo "ENERGI_WALLET_ADDR=${WALLET_ADDR}" >> ~/.bashrc
+echo "" >> ~/.bashrc
+echo "" >> ~/.bashrc
+
+echo ""
+echo "Please run 'source ~/.bashrc' without quotes or log out and back in again (once)."
+
+echo ""
+echo "Afterwards, please try the following:"
+echo ""
+echo " - energi3-unlock to unlock and start staking"
+echo " - energi3-status to obtain status"
+echo ""
+echo "More useful commands/scripts will be added in future!"
+echo ""
+
+exit 0


### PR DESCRIPTION
**Hi team!**

I was thinking about the AutoStaking idea I thought of, similar to the AutoCollateralize function.

Instead AutoStake will put the node into staking mode on start without needing to unlock the wallet with the passphrase.

In the meantime, I have created my own helper scripts which can be used. It only stores the wallet address, it does not store the password.

**install-scripts.sh** installs the scripts by adding to the PATH variable the location of the scripts/ folder
**energi3-unlock** will ask for a wallet address if there is none specified in .bashrc
**energi3-status** will give the status information

Add them in if you like after checking the source code 👍 

**Enjoy :)**